### PR TITLE
Don't disclose `ifbo.priors.utils` as `ifbo.utils`

### DIFF
--- a/ifbo/__init__.py
+++ b/ifbo/__init__.py
@@ -6,7 +6,7 @@ from .download import VERSION_MAP
 from .surrogate import FTPFN
 from .utils import Curve, PredictionResult
 
-from .priors import utils, ftpfn_prior
+from .priors import ftpfn_prior
 from .priors.utils import (
     get_batch_sequence as get_batch_sequence, get_batch_to_dataloader as get_batch_to_dataloader
 )


### PR DESCRIPTION
Partially resolve https://github.com/automl/ifBO/issues/2

## Motivations

The `ifbo/utils.py` includes several functions, but it is unavailable since `ifbo.priors.utils` is disclosed as `ifbo.utils`. This PR simply fix the module structures.

## Description of changes
- Remove `from .priors import utils` from `__init__.py`.