### PR TITLE
Add checks CI and apply linters

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -1,0 +1,23 @@
+name: Checks
+
+on:
+  push:
+      branches:
+          - main
+  pull_request: {}
+
+jobs:
+  checks:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
+      with:
+        python-version: 3.11
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install --progress-bar off -U .[checking]
+        pre-commit install
+    - name: Run checks
+      run: pre-commit run --all-files

--- a/ifbo/bar_distribution.py
+++ b/ifbo/bar_distribution.py
@@ -1,9 +1,8 @@
+import logging
 from typing import Any
 
 import torch
 from torch import nn
-
-import logging
 
 
 class BarDistribution(nn.Module):

--- a/ifbo/decoders.py
+++ b/ifbo/decoders.py
@@ -1,5 +1,3 @@
-import random
-
 import torch
 from torch import nn
 

--- a/ifbo/priors/ftpfn_prior.py
+++ b/ifbo/priors/ftpfn_prior.py
@@ -496,7 +496,7 @@ class MultiCurvesEncoder(torch.nn.Module):
             in_dim - 2, out_dim
         )
 
-    def forward(self, *x, **kwargs) -> torch.Tensor:
+    def forward(self, x: torch.Tensor, **kwargs: Any) -> torch.Tensor:
         x = torch.cat(x, dim=-1)
         out = (
             self.epoch_enc(self.normalizer(x[..., 1:2]))


### PR DESCRIPTION
I would like to introduce the CI for linters. The CI can greatly reduce the complexity of a codebase. By checking whether the Checks CI passes for each PR, the codebase can be kept simple in the future. Moreover, continuous type checking with tools like mypy can help discover hidden bugs.